### PR TITLE
output standardized BCP 47 language codes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="lumi_language_id",
-    version='0.2.1',
+    version='0.3',
     maintainer='Robyn Speer',
     maintainer_email='rspeer@luminoso.com',
     description='For when you want fastText language identification, but you also want to believe the answers',


### PR DESCRIPTION
We were outputting language codes from fastText's set, but these didn't match the language codes we use in wordfreq and exquisite-corpus, because they aren't all BCP-47-standardized.

- fastText's `no` should be `nb`
- fastText's `tl` should be `fil`
- fastText detects `sh` separately from `sr`, `hr`, and `bs` and that's weird, so `sh` normalizes to `sr`